### PR TITLE
Fixes 'search offers' query by type, and other small fixes.

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -361,13 +361,14 @@ def display_table(rows, fields):
         print("  ".join(out))
 
 @parser.command(
-    argument("-t", "--type", default="on-demand", help="whether to show `interruptible` or `on-demand` offers. default: on-demand"),
-    argument("-i", "--interruptible", dest="type", const="interruptible", action="store_const", help="Alias for --type=interruptible"),
+    argument("-t", "--type", default="on-demand", help="Show 'bid'(interruptible) or 'on-demand' offers. default: on-demand"),
+    argument("-i", "--interruptible", dest="type", const="bid", action="store_const", help="Alias for --type=bid"),
+    argument("-b", "--bid", dest="type", const="bid", action="store_const", help="Alias for --type=bid"),
     argument("-d", "--on-demand", dest="type", const="on-demand", action="store_const", help="Alias for --type=on-demand"),
     argument("-n", "--no-default", action="store_true", help="Disable default query"),
     argument("--disable-bundling", action="store_true", help="Show identical offers. This request is more heavily rate limited."),
-    argument("--storage", type=float, default=5.0, help="amount of storage to use for pricing, in GiB. default=5.0GiB"),
-    argument("-o", "--order", type=str, help="comma-separated list of fields to sort on. postfix field with - to sort desc. ex: -o 'num_gpus,total_flops-'.  default='score-'", default='score-'),
+    argument("--storage", type=float, default=5.0, help="Amount of storage to use for pricing, in GiB. default=5.0GiB"),
+    argument("-o", "--order", type=str, help="Comma-separated list of fields to sort on. postfix field with - to sort desc. ex: -o 'num_gpus,total_flops-'.  default='score-'", default='score-'),
     argument("query",            help="Query to search for. default: 'external=false rentable=true verified=true', pass -n to ignore default", nargs="*", default=None),
     usage="vast search offers [--help] [--api-key API_KEY] [--raw] <query>",
     epilog=deindent("""
@@ -462,6 +463,9 @@ def search__offers(args):
 
         query["order"] = order
         query["type"]  = args.type
+        # For backwards compatibility, support --type=interruptible option
+        if query["type"] == 'interruptible':
+            query["type"] = 'bid'
         if args.disable_bundling:
             query["disable_bundling"] = True
     except ValueError as e:

--- a/vast.py
+++ b/vast.py
@@ -854,7 +854,8 @@ def set__api_key(args):
     argument("email",    help="Email"),
     argument("password",    help="Password"),
     #argument("--ssh-key",     help="The SSH Pubkey you'd like to use to connect to containers"),
-    usage = "vast create account [--api-key API_KEY] [--ssh-key SSH_KEY] USERNAME PASSWORD",
+    #usage = "vast create account [--api-key API_KEY] [--ssh-key SSH_KEY] USERNAME PASSWORD",
+    usage = "vast create account [--api-key API_KEY] USERNAME PASSWORD",
 )
 def create__account(args):
     if args.username is None:
@@ -879,8 +880,9 @@ def create__account(args):
 @parser.command(
     argument("username",    help="Username or Email", nargs="?", default=None),
     argument("password",    help="Password", nargs="?", default=None),
-    argument("--ssh-key",     help="The SSH Pubkey you'd like to use to connect to containers"),
-    usage = "vast login [--username USERNAME] [--password PASSWORD] [--api-key API_KEY] [--ssh-key SSH_KEY]",
+    #argument("--ssh-key",     help="The SSH Pubkey you'd like to use to connect to containers"),
+    #usage = "vast login [--username USERNAME] [--password PASSWORD] [--api-key API_KEY] [--ssh-key SSH_KEY]",
+    usage = "vast login [--username USERNAME] [--password PASSWORD] [--api-key API_KEY]",
 )
 def login(args):
     if args.username is None:

--- a/vast.py
+++ b/vast.py
@@ -559,7 +559,7 @@ def list__machine(args):
 
 
 @parser.command(
-    argument("id",          help="id of machine to list", type=int),
+    argument("id",          help="id of machine to unlist", type=int),
     usage = "vast unlist machine <id>",
 )
 def unlist__machine(args):
@@ -748,7 +748,7 @@ def set__defjob(args):
     argument("--onstart-cmd", help="contents of onstart script as single argument", type=str),
     argument("--jupyter",     help="Launch as a jupyter instance instead of an ssh instance.", action="store_true"),
     argument("--jupyter-dir", help="For runtype 'jupyter', directory in instance to use to launch jupyter. Defaults to image's working directory.", type=str),
-    argument("--jupyter-lab", help="For runtype 'jupyter', directory in instance to use to launch jupyter. Defaults to image's working directory.", action="store_true"),
+    argument("--jupyter-lab", help="For runtype 'jupyter', Launch instance with jupyter lab.", action="store_true"),
     argument("--lang-utf8",   help="Workaround for images with locale problems: install and generate locales before instance launch, and set locale to C.UTF-8.", action="store_true"),
     argument("--python-utf8", help="Workaround for images with locale problems: set python's locale to C.UTF-8.", action="store_true"),
     argument("--extra",       help=argparse.SUPPRESS),
@@ -797,7 +797,7 @@ def create__instance(args):
         print("Started. {}".format(r.json()))
 
 @parser.command(
-    argument("id",            help="id of instance type to launch", type=int),
+    argument("id",            help="id of instance type to change bid", type=int),
     argument("--price",       help="per machine bid price in $/hour", type=float),
     usage = "vast change bid id [--price PRICE]",
     epilog = deindent("""

--- a/vast.py
+++ b/vast.py
@@ -262,7 +262,7 @@ def parse_query(query_str, res=None):
         "disk_bw",
         "disk_space",
         "dlperf",
-        "dlperf_per_dphtotal"
+        "dlperf_per_dphtotal",
         "dph_total",
         "duration",
         "external",


### PR DESCRIPTION
- Fixes 'search offers' to allow query by type (changed `--type=interruptible` to `--type=bid`)
    - Adds a command line option `-b` (for "bid") which aliases `--type=bid`
    - For backwards compatibility, `--type=interruptible` is converted to `--type=bid`.
- Fixes error message caused when querying by 'dph'. 
- Fixed some duplicated and incorrect help prompts.