### PR TITLE
add a `vast show invoices` command

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -506,7 +506,21 @@ def show__instances(args):
         #    cost = str(float(instance["dph_total"]));
         #    print("%-10s%-10s%-12s%-2s x %-16s%-6i%-5i%3iGB   %5iGB   %-16s%-9s%-8s%-12s" % (instance["id"], instance["machine_id"], instance["actual_status"], 1*instance["num_gpus"], instance["gpu_name"], gpu_util, int(instance["cpu_cores"]), int(instance["cpu_ram"])/1000, int(instance["disk_space"]), instance["ssh_host"], instance["ssh_port"], cost[0:5], instance["image_uuid"]));
         #    #print("{id}: {json}".format(id=instance["id"], json=json.dumps(instance, indent=4, sort_keys=True)))
-    
+
+
+
+@parser.command(
+    usage="vast show invoices",
+)
+def show__invoices(args):
+    req_url = apiurl(args, "/users/me/invoices");
+    print(req_url);
+    r = requests.get(req_url);
+    r.raise_for_status()
+    rows = r.json()["invoices"]
+    print(json.dumps(rows, indent=1, sort_keys=True))
+
+
 
 @parser.command(
     argument("-q", "--quiet", action="store_true", help="only display numeric ids"),


### PR DESCRIPTION
This command shows the JSON which is used by the billing page of the vast.ai website.
It can only show it in Raw JSON format for now.

I added this command because the website of vast.ai no longer renders my invoices.
I assume that it just contains too much data.

Occasionally I do get a couple of PDF files, but then still my bookkeeper is pretty confused.
A better solution probably would be to make a clearer distinction between credit consumption and money transfer.
I mean, right now the invoice document is actually more like a mixture of an invoice and a credit consumption report.
And mostly the "Total" listed on top of the PDF file is confusing my bookkeeper + the fact that an invoice is several pages long and does contain a lot of neglectable numbers. (0$ amounts).

So, I wil try to give my bookkeeper 3 numbers:
- payments made by me / month.
- available credits at the start of the month.
- available credits at the end of the month.

To make these calculations I of course need the data. And that is where this command comes in.

**More importantly for this Pull Request:**
 - I tested it, and it works.