### PR TITLE
fixing invite team member bug

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -1327,7 +1327,7 @@ def execute(args):
     help="Invite a team member",
 )
 def invite__team_member(args):
-    url = apiurl(args, "/team/invite/", json={"email": args.email, "role": args.role})
+    url = apiurl(args, "/team/invite/", query_args={"email": args.email, "role": args.role})
     r = requests.post(url, headers=headers)
     r.raise_for_status()
     print(r.json())


### PR DESCRIPTION
having json as param was making people fail when doing team invitations