### PR TITLE
Fix runtype = None

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -1167,6 +1167,8 @@ def get_runtype(args):
     if args.ssh:
         runtype = 'ssh_direc ssh_proxy' if args.direct else 'ssh_proxy'
 
+    return runtype
+
 
 @parser.command(
     argument("ID", help="id of instance type to launch (returned from search offers)", type=int),


### PR DESCRIPTION
None runtype returned keeping the user to specify another mode of connection