### PR TITLE
Add VAST_API_KEY environment variable

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -4512,7 +4512,7 @@ def main():
     parser.add_argument("--retry", help="retry limit", default=3)
     parser.add_argument("--raw", action="store_true", help="output machine-readable json")
     parser.add_argument("--explain", action="store_true", help="output verbose explanation of mapping of CLI calls to HTTPS API endpoints")
-    parser.add_argument("--api-key", help="api key. defaults to using the one stored in {}".format(api_key_file_base), type=str, required=False, default=api_key_guard)
+    parser.add_argument("--api-key", help="api key. defaults to using the one stored in {}".format(api_key_file_base), type=str, required=False, default=os.getenv("VAST_API_KEY", api_key_guard))
 
 
     args = parser.parse_args()


### PR DESCRIPTION
Ty for the CLI. I think it's appropriate to allow customizing the API key without having to specify the --api-key CLI arg. 