### PR TITLE
Change stop instance message to print "stopping"

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -2448,7 +2448,7 @@ def stop_instance(id,args):
     if (r.status_code == 200):
         rj = r.json()
         if (rj["success"]):
-            print("starting instance {id}.".format(**(locals())))
+            print("stopping instance {id}.".format(**(locals())))
         else:
             print(rj["msg"])
         return True


### PR DESCRIPTION
before
```
$ vastai stop instance 13378114
starting instance 13378114.
```

after:
```
$ python3 vast.py stop instance 13389788
stopping instance 13389788.
```