### PR TITLE
Fixes #142 exit code sometimes changed

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -4809,12 +4809,12 @@ def main():
         headers["Authorization"] = "Bearer " + args.api_key
 
     if TABCOMPLETE:
-      myautocc = MyAutocomplete()
-      myautocc(parser.parser)
+        myautocc = MyAutocomplete()
+        myautocc(parser.parser)
 
     try:
         res = args.func(args)
-        if res:
+        if args.raw:
             # There's two types of responses right now
             try:
                 print(json.dumps(res, indent=1, sort_keys=True))


### PR DESCRIPTION
Gating the new output now on args.raw instead of the return value which could sometimes return things like [] which sys.exit (specifically _Py_HandleSystemExit) would return a 1 on.

Now the behavior is if args.raw was specified, it exits(0) which of course could eventually have other potential side effects for exception path handling.

Regardless, that seems to not currently be a problem and quick fixes are nice.